### PR TITLE
delete mapActions because this function is unused

### DIFF
--- a/src/components/Counter.vue
+++ b/src/components/Counter.vue
@@ -7,8 +7,6 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
-
 export default {
   name: 'counter',
   methods: {


### PR DESCRIPTION
Hi, there! 

I deleted mapActions because this function is unused. How do you think?